### PR TITLE
検索途中の候補表示を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,12 @@ Astro 7のレスポンシブ画像機能とSharpにより、Markdown内の画像
 - Commits: concise, present-tense messages (Japanese is fine), focused scope. Examples: `Astroを5.13.3へアップデート`, `タグの大文字小文字を正規化`.
 - PRs: include a summary, linked issues, and UI screenshots when relevant. Ensure `pnpm lint` and `pnpm build` pass. Describe any content migrations or alias changes.
 
+### GitHub CLI認証
+
+- `gh`はmacOSのキーチェーンに保存された認証情報を使用するため、Codexの制限環境内では`gh auth status`が誤って未認証または無効なトークンと判定されることがある。
+- commit後のpush、PR作成、PR確認、mergeなどで`gh`を使用する場合は、ホスト環境で`gh auth status`を実行して認証状態を確認する。制限環境内の失敗だけを理由に再ログインしない。
+- ホスト環境でも認証に失敗した場合のみ、`gh auth login -h github.com`で再認証し、続けて`gh auth status`を確認する。
+
 ### Branching
 
 - 既定ブランチは `master` です（旧 `main` から移行）。

--- a/docs/search-and-related-posts.md
+++ b/docs/search-and-related-posts.md
@@ -15,7 +15,9 @@
 
 - `pagefind.yml`: Pagefindの索引対象を投稿詳細HTMLへ限定する。
 - `src/pages/search.astro`: Pagefind Search APIを使う検索画面。
-- `src/components/Header.astro`: PC・モバイル用の検索フォーム。
+- `src/components/Header.astro`: PC・モバイル用の検索候補UIの配置。
+- `src/components/SearchSuggestions.astro`: 検索候補の表示とキーボード操作。
+- `src/lib/pagefind-client.ts`: Pagefindの遅延ロードと検索処理を共通化するクライアント。
 - `astro.config.mjs`: ビルド済みPagefindバンドルを開発サーバーから配信するViteプラグイン。
 - `src/lib/related-posts.ts`: 本文類似度の計算とランキング。
 - `src/components/RelatedPosts.astro`: 関連記事の表示。
@@ -42,6 +44,20 @@ Pagefindは`dist/posts/**/p*/index.html`だけを読み、`data-pagefind-body`�
 
 検索画面は`/pagefind/pagefind.js`を遅延ロードし、300ミリ秒のデバウンス後に検索する。結果は最大50件で、日付、タイトル、本文抜粋、タグを表示する。DOMは`innerHTML`で組み立てず、テキストノードを使って検索語をハイライトする。
 
+### 入力途中の検索候補
+
+ヘッダーのPC・モバイル検索欄では、2文字以上の入力後にPagefindを検索し、上位5件を候補として表示する。別の索引やサーバーAPIは追加せず、検索画面と同じPagefind索引と`src/lib/pagefind-client.ts`を共有する。
+
+候補には日付、タイトル、本文抜粋を表示する。候補を選ばずEnterを押した場合は従来どおり`/search?q=...`へ移動し、「すべての検索結果を見る」からも全件表示へ移動できる。
+
+操作とアクセシビリティは次のとおり。
+
+- 入力欄はARIA combobox、候補一覧はlistboxとして公開する。
+- 上下キーで候補を移動し、Enterで選択した記事へ移動する。
+- Escapeまたは候補UIの外側をクリックすると閉じる。
+- 入力欄へフォーカスした時点でPagefindを先読みし、初回検索の待ち時間を短縮する。
+- 新しい入力が行われた場合は古い検索結果を破棄し、遅れて返った候補で表示を上書きしない。
+
 ### 開発サーバー
 
 Pagefindは生成済みHTMLから索引を作るため、`astro dev`だけでは索引を生成できない。ローカルでは次の順番で起動する。
@@ -51,7 +67,7 @@ pnpm build
 pnpm dev
 ```
 
-`astro.config.mjs`の開発専用Viteプラグインが、`dist/pagefind`内の実ファイルだけを`/pagefind/`から配信する。`dist`全体は公開せず、パスを正規化してディレクトリ外へのアクセスを拒否する。コンテンツ更新後は再度`pnpm build`を実行し、開発サーバーを再起動する。
+`astro.config.mjs`の開発専用Viteプラグインが、`dist/pagefind`内の実ファイルだけを`/pagefind/`から配信する。`dist`全体は公開せず、パスを正規化してディレクトリ外へのアクセスを拒否する。コンテンツ更新後は再度`pnpm build`を実行し、開発サーバーを再起動する。検索候補も同じ索引を使うため、この前提は共通である。
 
 ## 関連記事
 
@@ -128,4 +144,4 @@ pnpm test:e2e:dev    # astro devでビルド済み索引と関連記事を確認
 pnpm verify          # 上記を含む全検証
 ```
 
-`tests/related-posts.test.ts`は本文の類似度が高い記事を優先すること、自分自身と同日記事を除外すること、同点時の並び順を検証する。`tests/output/build-output.test.ts`は全生成記事について関連記事が最大3件で、存在する`/posts/YYYYMMDD/pNN`を指し、同日記事を含まないことを検証する。
+`tests/related-posts.test.ts`は本文の類似度が高い記事を優先すること、自分自身と同日記事を除外すること、同点時の並び順を検証する。`tests/output/build-output.test.ts`は全生成記事について関連記事が最大3件で、存在する`/posts/YYYYMMDD/pNN`を指し、同日記事を含まないことを検証する。PlaywrightのE2Eでは、PC・モバイルの候補表示、キーボード選択、Escapeで閉じる操作、および開発サーバーから候補を取得できることを確認する。

--- a/playwright.dev.config.ts
+++ b/playwright.dev.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     trace: "on-first-retry",
   },
   webServer: {
-    command: `ASTRO_DEV_BACKGROUND=0 pnpm dev --host 127.0.0.1 --port ${port}`,
+    command: `ASTRO_DEV_BACKGROUND=0 pnpm dev --ignore-lock --host 127.0.0.1 --port ${port}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,6 +5,7 @@
  * - 右: 最新 / 検索 / タグ / 年別 へのナビゲーション
  * - モバイルでは検索ボタンから検索フォームを展開
  */
+import SearchSuggestions from "@/components/SearchSuggestions.astro";
 ---
 
 <header class="border-border border-b bg-[#e9f4fb] dark:bg-[#0f1f2d]">
@@ -12,28 +13,12 @@
     <a href="/" class="text-lg font-bold">まちゅダイアリー</a>
     <nav class="flex items-center gap-2 text-sm sm:gap-4">
       <a href="/" class="hover:underline">最新</a>
-      <form
-        action="/search"
-        method="get"
-        class="hidden items-center gap-1 md:flex"
-      >
-        <label for="header-search-input" class="sr-only">記事を検索</label>
-        <input
-          id="header-search-input"
-          type="search"
-          name="q"
-          placeholder="検索…"
-          autocomplete="off"
-          class="border-border bg-background text-foreground placeholder:text-muted-foreground focus:ring-ring w-32 rounded-md border px-2 py-1 text-sm focus:ring-2 focus:outline-none lg:w-40"
-        />
-        <button
-          type="submit"
-          class="text-muted-foreground hover:text-foreground"
-          aria-label="検索"
-        >
-          <i class="fa-solid fa-magnifying-glass text-xs"></i>
-        </button>
-      </form>
+      <SearchSuggestions
+        id="header-search"
+        placeholder="検索…"
+        compact
+        wrapperClass="hidden md:block"
+      />
       <button
         id="search-toggle"
         type="button"
@@ -59,23 +44,7 @@
   </div>
 
   <div id="mobile-search" class="container hidden pb-4 md:hidden">
-    <form action="/search" method="get" class="flex items-center gap-2">
-      <label for="mobile-search-input" class="sr-only">記事を検索</label>
-      <input
-        id="mobile-search-input"
-        type="search"
-        name="q"
-        placeholder="キーワードを入力…"
-        autocomplete="off"
-        class="border-border bg-background text-foreground placeholder:text-muted-foreground focus:ring-ring min-w-0 flex-1 rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
-      />
-      <button
-        type="submit"
-        class="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md border px-3 py-2 text-sm font-medium"
-      >
-        検索
-      </button>
-    </form>
+    <SearchSuggestions id="mobile-search" placeholder="キーワードを入力…" />
   </div>
 
   <script>
@@ -106,7 +75,7 @@
       );
       if (willOpen) {
         const input = mobileSearch?.querySelector<HTMLInputElement>(
-          'input[type="search"]',
+          "[data-search-suggestions-input]",
         );
         input?.focus();
       }

--- a/src/components/SearchSuggestions.astro
+++ b/src/components/SearchSuggestions.astro
@@ -1,0 +1,294 @@
+---
+interface Props {
+  id: string;
+  placeholder: string;
+  compact?: boolean;
+  wrapperClass?: string;
+}
+
+const { id, placeholder, compact = false, wrapperClass = "" } = Astro.props;
+const inputId = `${id}-input`;
+const panelId = `${id}-suggestions`;
+const listId = `${id}-suggestions-list`;
+---
+
+<div class:list={["relative", wrapperClass]} data-search-suggestions>
+  <form
+    action="/search"
+    method="get"
+    class="flex items-center gap-1"
+    role="search"
+  >
+    <label for={inputId} class="sr-only">記事を検索</label>
+    <input
+      id={inputId}
+      type="search"
+      name="q"
+      placeholder={placeholder}
+      autocomplete="off"
+      role="combobox"
+      aria-autocomplete="list"
+      aria-haspopup="listbox"
+      aria-controls={listId}
+      aria-expanded="false"
+      data-search-suggestions-input
+      class:list={[
+        "border-border bg-background text-foreground placeholder:text-muted-foreground focus:ring-ring min-w-0 rounded-md border text-sm focus:ring-2 focus:outline-none",
+        compact ? "w-32 px-2 py-1 lg:w-40" : "flex-1 px-3 py-2",
+      ]}
+    />
+    <button
+      type="submit"
+      class:list={[
+        compact
+          ? "text-muted-foreground hover:text-foreground"
+          : "bg-primary text-primary-foreground hover:bg-primary/90 rounded-md border px-3 py-2 text-sm font-medium",
+      ]}
+      aria-label={compact ? "検索" : undefined}
+    >
+      {compact ? <i class="fa-solid fa-magnifying-glass text-xs" /> : "検索"}
+    </button>
+  </form>
+
+  <div
+    id={panelId}
+    data-search-suggestions-panel
+    class:list={[
+      "border-border bg-background absolute z-50 mt-2 hidden overflow-hidden rounded-md border shadow-xl",
+      compact ? "right-0 w-96" : "inset-x-0",
+    ]}
+  >
+    <p
+      class="text-muted-foreground px-3 py-3 text-sm"
+      data-search-suggestions-message
+      aria-live="polite"
+    >
+    </p>
+    <ul
+      id={listId}
+      role="listbox"
+      data-search-suggestions-list
+      class="max-h-96 overflow-y-auto py-1"
+    >
+    </ul>
+    <a
+      href="/search"
+      data-search-suggestions-all
+      class="border-border hover:bg-muted block border-t px-3 py-2 text-center text-sm font-medium"
+    >
+      すべての検索結果を見る
+    </a>
+  </div>
+</div>
+
+<script>
+  import {
+    searchPagefind,
+    warmPagefind,
+    type PagefindData,
+  } from "@/lib/pagefind-client";
+
+  const MIN_QUERY_LENGTH = 2;
+  const MAX_SUGGESTIONS = 5;
+
+  function createSuggestion(
+    data: PagefindData,
+    inputId: string,
+    index: number,
+  ): HTMLLIElement {
+    const item = document.createElement("li");
+    item.setAttribute("role", "none");
+
+    const link = document.createElement("a");
+    link.id = `${inputId}-option-${index}`;
+    link.href = data.url;
+    link.setAttribute("role", "option");
+    link.setAttribute("aria-selected", "false");
+    link.className = "block px-3 py-2 hover:bg-muted";
+
+    const date = document.createElement("p");
+    date.className = "text-xs text-muted-foreground";
+    date.textContent = data.meta.date ?? "";
+    link.append(date);
+
+    const title = document.createElement("p");
+    title.className = "mt-0.5 truncate text-sm font-semibold";
+    title.textContent = data.meta.title ?? data.url;
+    link.append(title);
+
+    const excerpt = document.createElement("p");
+    excerpt.className = "mt-0.5 text-xs text-muted-foreground line-clamp-2";
+    excerpt.textContent = data.plain_excerpt;
+    link.append(excerpt);
+
+    item.append(link);
+    return item;
+  }
+
+  function setupSuggestions(root: HTMLElement): void {
+    const inputElement = root.querySelector<HTMLInputElement>(
+      "[data-search-suggestions-input]",
+    );
+    const panelElement = root.querySelector<HTMLElement>(
+      "[data-search-suggestions-panel]",
+    );
+    const listElement = root.querySelector<HTMLUListElement>(
+      "[data-search-suggestions-list]",
+    );
+    const messageElement = root.querySelector<HTMLElement>(
+      "[data-search-suggestions-message]",
+    );
+    const allResultsElement = root.querySelector<HTMLAnchorElement>(
+      "[data-search-suggestions-all]",
+    );
+    if (
+      !inputElement ||
+      !panelElement ||
+      !listElement ||
+      !messageElement ||
+      !allResultsElement
+    )
+      return;
+
+    const input = inputElement;
+    const panel = panelElement;
+    const list = listElement;
+    const message = messageElement;
+    const allResults = allResultsElement;
+
+    let activeIndex = -1;
+    let searchSequence = 0;
+
+    function options(): HTMLAnchorElement[] {
+      return [...list.querySelectorAll<HTMLAnchorElement>('[role="option"]')];
+    }
+
+    function open(): void {
+      panel.classList.remove("hidden");
+      input.setAttribute("aria-expanded", "true");
+    }
+
+    function close(): void {
+      panel.classList.add("hidden");
+      input.setAttribute("aria-expanded", "false");
+      input.removeAttribute("aria-activedescendant");
+      activeIndex = -1;
+      for (const option of options()) {
+        option.setAttribute("aria-selected", "false");
+        option.classList.remove("bg-muted");
+      }
+    }
+
+    function setActive(index: number): void {
+      const candidates = options();
+      if (candidates.length === 0) return;
+      activeIndex = (index + candidates.length) % candidates.length;
+
+      candidates.forEach((candidate, candidateIndex) => {
+        const active = candidateIndex === activeIndex;
+        candidate.setAttribute("aria-selected", String(active));
+        candidate.classList.toggle("bg-muted", active);
+      });
+
+      const active = candidates[activeIndex];
+      input.setAttribute("aria-activedescendant", active.id);
+      active.scrollIntoView({ block: "nearest" });
+    }
+
+    function showMessage(text: string, showAllResults: boolean): void {
+      list.replaceChildren();
+      message.textContent = text;
+      message.classList.remove("hidden");
+      allResults.classList.toggle("hidden", !showAllResults);
+      activeIndex = -1;
+      input.removeAttribute("aria-activedescendant");
+      open();
+    }
+
+    async function updateSuggestions(): Promise<void> {
+      const query = input.value.trim();
+      const sequence = ++searchSequence;
+
+      if (!query) {
+        close();
+        return;
+      }
+
+      const searchUrl = `/search?q=${encodeURIComponent(query)}`;
+      allResults.href = searchUrl;
+      if ([...query].length < MIN_QUERY_LENGTH) {
+        showMessage("2文字以上入力すると候補を表示します。", true);
+        return;
+      }
+
+      showMessage("検索中…", false);
+      try {
+        const response = await searchPagefind(query, MAX_SUGGESTIONS, 300);
+        if (!response || sequence !== searchSequence) return;
+
+        list.replaceChildren(
+          ...response.entries.map((entry, index) =>
+            createSuggestion(entry, input.id, index),
+          ),
+        );
+        message.classList.toggle("hidden", response.total > 0);
+        message.textContent =
+          response.total > 0 ? "" : "一致する記事は見つかりませんでした。";
+        allResults.classList.remove("hidden");
+        activeIndex = -1;
+        input.removeAttribute("aria-activedescendant");
+        open();
+      } catch (error) {
+        console.error("Failed to load search suggestions", error);
+        if (sequence === searchSequence) {
+          showMessage("検索候補を読み込めませんでした。", true);
+        }
+      }
+    }
+
+    input.addEventListener("focus", () => {
+      void warmPagefind(input.value.trim()).catch(() => undefined);
+      if (
+        input.value.trim() &&
+        (list.childElementCount > 0 || message.textContent)
+      ) {
+        open();
+      }
+    });
+    input.addEventListener("input", () => void updateSuggestions());
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        close();
+        return;
+      }
+
+      if (panel.classList.contains("hidden")) return;
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActive(activeIndex + 1);
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActive(activeIndex - 1);
+      } else if (event.key === "Enter" && activeIndex >= 0) {
+        const active = options()[activeIndex];
+        if (active) {
+          event.preventDefault();
+          window.location.assign(active.href);
+        }
+      }
+    });
+
+    root.addEventListener("focusout", () => {
+      window.setTimeout(() => {
+        if (!root.contains(document.activeElement)) close();
+      });
+    });
+    document.addEventListener("pointerdown", (event) => {
+      if (event.target instanceof Node && !root.contains(event.target)) close();
+    });
+  }
+
+  document
+    .querySelectorAll<HTMLElement>("[data-search-suggestions]")
+    .forEach(setupSuggestions);
+</script>

--- a/src/lib/pagefind-client.ts
+++ b/src/lib/pagefind-client.ts
@@ -1,0 +1,63 @@
+export interface PagefindData {
+  url: string;
+  plain_excerpt: string;
+  meta: Record<string, string | undefined>;
+}
+
+interface PagefindResult {
+  data: () => Promise<PagefindData>;
+}
+
+interface PagefindResponse {
+  results: PagefindResult[];
+}
+
+interface PagefindApi {
+  init?: () => Promise<void>;
+  preload?: (query: string, options?: Record<string, unknown>) => Promise<void>;
+  debouncedSearch: (
+    query: string,
+    options?: Record<string, unknown>,
+    debounceMs?: number,
+  ) => Promise<PagefindResponse | null>;
+}
+
+export interface PagefindSearchResult {
+  total: number;
+  entries: PagefindData[];
+}
+
+let pagefindPromise: Promise<PagefindApi> | undefined;
+
+function loadPagefind(): Promise<PagefindApi> {
+  const pagefindUrl = "/pagefind/pagefind.js";
+  pagefindPromise ??= import(/* @vite-ignore */ pagefindUrl).then(
+    (module) => module as PagefindApi,
+  );
+  return pagefindPromise;
+}
+
+export async function warmPagefind(query = ""): Promise<void> {
+  const pagefind = await loadPagefind();
+  if (query && pagefind.preload) {
+    await pagefind.preload(query);
+    return;
+  }
+  await pagefind.init?.();
+}
+
+export async function searchPagefind(
+  query: string,
+  limit: number,
+  debounceMs = 300,
+): Promise<PagefindSearchResult | null> {
+  const pagefind = await loadPagefind();
+  const response = await pagefind.debouncedSearch(query, {}, debounceMs);
+  if (!response) return null;
+
+  const visible = response.results.slice(0, limit);
+  return {
+    total: response.results.length,
+    entries: await Promise.all(visible.map((result) => result.data())),
+  };
+}

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -44,28 +44,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 
   <script>
     import { normalizeTag } from "@/lib/tags";
-
-    interface PagefindData {
-      url: string;
-      plain_excerpt: string;
-      meta: Record<string, string | undefined>;
-    }
-
-    interface PagefindResult {
-      data: () => Promise<PagefindData>;
-    }
-
-    interface PagefindResponse {
-      results: PagefindResult[];
-    }
-
-    interface PagefindApi {
-      debouncedSearch: (
-        query: string,
-        options?: Record<string, unknown>,
-        debounceMs?: number,
-      ) => Promise<PagefindResponse | null>;
-    }
+    import { searchPagefind, type PagefindData } from "@/lib/pagefind-client";
 
     const MAX_RESULTS = 50;
     const input = document.querySelector<HTMLInputElement>("#search-input");
@@ -73,16 +52,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
     const status = document.querySelector<HTMLElement>("#search-status");
     const results = document.querySelector<HTMLUListElement>("#search-results");
 
-    let pagefindPromise: Promise<PagefindApi> | undefined;
     let searchSequence = 0;
-
-    function loadPagefind(): Promise<PagefindApi> {
-      const pagefindUrl = "/pagefind/pagefind.js";
-      pagefindPromise ??= import(/* @vite-ignore */ pagefindUrl).then(
-        (module) => module as PagefindApi,
-      );
-      return pagefindPromise;
-    }
 
     function queryTerms(query: string): string[] {
       return query.trim().split(/\s+/).filter(Boolean);
@@ -188,25 +158,22 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 
       status.textContent = "検索中…";
       try {
-        const pagefind = await loadPagefind();
-        const response = await pagefind.debouncedSearch(trimmed, {}, 300);
+        const response = await searchPagefind(trimmed, MAX_RESULTS, 300);
         if (!response || sequence !== searchSequence) return;
 
-        const visible = response.results.slice(0, MAX_RESULTS);
-        const data = await Promise.all(visible.map((result) => result.data()));
-        if (sequence !== searchSequence) return;
-
-        if (response.results.length === 0) {
+        if (response.total === 0) {
           status.textContent = `「${trimmed}」に一致する記事は見つかりませんでした。`;
           return;
         }
 
         status.textContent =
-          response.results.length > MAX_RESULTS
-            ? `${response.results.length}件の記事が見つかりました。先頭${MAX_RESULTS}件を表示しています。`
-            : `${response.results.length}件の記事が見つかりました。`;
+          response.total > MAX_RESULTS
+            ? `${response.total}件の記事が見つかりました。先頭${MAX_RESULTS}件を表示しています。`
+            : `${response.total}件の記事が見つかりました。`;
         const terms = queryTerms(trimmed);
-        results.append(...data.map((entry) => renderResult(entry, terms)));
+        results.append(
+          ...response.entries.map((entry) => renderResult(entry, terms)),
+        );
       } catch (error) {
         console.error("Failed to load the Pagefind index", error);
         if (sequence === searchSequence) {

--- a/tests/e2e-dev/development.spec.ts
+++ b/tests/e2e-dev/development.spec.ts
@@ -6,6 +6,9 @@ test("serves the built Pagefind index from the development server", async ({
   await page.goto("/");
   const search = page.locator("#header-search-input");
   await search.fill("OpenID");
+  await expect(
+    page.locator("#header-search-suggestions-list [role=option]"),
+  ).toHaveCount(5);
   await search.press("Enter");
 
   await expect(page).toHaveURL(/\/search\?q=OpenID$/);

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -63,6 +63,31 @@ test("searches the full-text index from the header", async ({ page }) => {
   expect(slug).toBe(slug.trim().toLowerCase());
 });
 
+test("shows and keyboard-navigates header search suggestions", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const search = page.locator("#header-search-input");
+  const panel = page.locator("#header-search-suggestions");
+  const options = page.locator("#header-search-suggestions-list [role=option]");
+
+  await search.fill("OpenID");
+  await expect(options).toHaveCount(5);
+  await expect(panel).toBeVisible();
+
+  await search.press("ArrowDown");
+  const activeId = await search.getAttribute("aria-activedescendant");
+  expect(activeId).toBe("header-search-input-option-0");
+  await expect(page.locator(`#${activeId}`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  await search.press("Escape");
+  await expect(panel).toBeHidden();
+  await expect(search).not.toHaveAttribute("aria-activedescendant", /.+/);
+});
+
 test("opens the mobile search form", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
@@ -71,4 +96,9 @@ test("opens the mobile search form", async ({ page }) => {
   const input = page.locator("#mobile-search-input");
   await expect(input).toBeVisible();
   await expect(input).toBeFocused();
+
+  await input.fill("OpenID");
+  await expect(
+    page.locator("#mobile-search-suggestions-list [role=option]"),
+  ).toHaveCount(5);
 });

--- a/tests/output/build-output.test.ts
+++ b/tests/output/build-output.test.ts
@@ -46,8 +46,15 @@ describe("generated HTML", () => {
 describe("site search", () => {
   it("emits the search page and Pagefind bundle", async () => {
     const { $ } = await readDocument("search/index.html");
-    expect($('form[role="search"][action="/search"]').length).toBe(1);
     expect($("#search-input").attr("name")).toBe("q");
+    expect(
+      $("#search-input").closest('form[role="search"][action="/search"]')
+        .length,
+    ).toBe(1);
+    expect($("#header-search-input").attr("role")).toBe("combobox");
+    expect($("#header-search-suggestions-list").attr("role")).toBe("listbox");
+    expect($("#mobile-search-input").attr("role")).toBe("combobox");
+    expect($("#mobile-search-suggestions-list").attr("role")).toBe("listbox");
     expect(await outputPathExists("pagefind/pagefind.js")).toBe(true);
     expect(await outputPathExists("pagefind/pagefind-worker.js")).toBe(true);
   });


### PR DESCRIPTION
## 概要

- ヘッダーのPC・モバイル検索欄にPagefindベースの入力途中候補を追加
- 検索画面と候補表示でPagefindクライアントを共通化
- キーボード操作とARIA combobox/listboxに対応
- GitHub CLIの認証確認手順をAGENTS.mdへ追記

## 背景

検索結果ページへ移動する前に候補を確認できるようにし、既存のPagefind索引を追加インフラなしで再利用します。`pnpm dev`では従来どおり、先に`pnpm build`で生成した索引を利用します。

## 検証

- `pnpm exec astro check`
- `pnpm lint`
- `pnpm test`（22件）
- `pnpm build`（1,507記事を索引化）
- `pnpm test:output`（12件）
- `pnpm test:e2e`（7件）
- `pnpm test:e2e:dev`（2件）